### PR TITLE
Fixed miss typing variable name

### DIFF
--- a/src/functions/util/let.md
+++ b/src/functions/util/let.md
@@ -28,7 +28,7 @@ This will return `Ayaka` from `$get`:
 bot.command({
   name: 'let',
   code: `
-$get[Ayaka]
+$get[genius]
 $let[genius;Ayaka]
 `
 });


### PR DESCRIPTION
Instead making it value, I've changed it to variable on $get function. #4 